### PR TITLE
feat: add @tresjs/rapier ecosystem package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The CLI includes options for the following TresJS ecosystem packages:
 - **@tresjs/cientos** - Collection of useful helpers and ready-made abstractions
 - **@tresjs/post-processing** - Post-processing effects for TresJS
 - **@tresjs/leches** - Tasty GUI controls for development
+- **@tresjs/rapier** - Physics for TresJS, powered by Rapier
 - **@tresjs/path-tracing** - Path-tracing rendering capabilities
 
 ## Development

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,23 @@ const ECOSYSTEM_PACKAGES = [
     description: 'Tasty GUI controls for development',
     value: 'leches'
   },
+  {
+    name: '@tresjs/rapier',
+    description: 'Physics for TresJS, powered by Rapier',
+    value: 'rapier'
+  },
   /* {
     name: '@tresjs/path-tracing',
     description: 'Path-tracing rendering capabilities',
     value: 'path-tracing'
   } */
 ]
+
+// Path of the demo component each template renders, relative to the project root
+const EXPERIENCE_COMPONENT_PATH: Record<ProjectOptions['template'], string> = {
+  vue: path.join('src', 'components', 'TheExperience.vue'),
+  nuxt: path.join('components', 'TheExperience.vue')
+}
 
 function validatePackageName(name: string): boolean {
   const validation = validateProjectName(name)
@@ -93,6 +104,19 @@ async function replaceTemplateVariables(targetDir: string, projectName: string):
   }
 }
 
+// Swaps the default demo component for one showcasing the selected package
+async function applyPackageVariant(
+  targetDir: string,
+  template: ProjectOptions['template'],
+  variant: string
+): Promise<void> {
+  const variantFile = path.join(__dirname, '..', 'templates', 'variants', variant, template, 'TheExperience.vue')
+
+  if (!await fs.pathExists(variantFile)) return
+
+  await fs.copy(variantFile, path.join(targetDir, EXPERIENCE_COMPONENT_PATH[template]))
+}
+
 async function createProject(options: ProjectOptions): Promise<void> {
   const { name, template, eslint, packages, packageManager } = options
   
@@ -104,7 +128,11 @@ async function createProject(options: ProjectOptions): Promise<void> {
   // Copy template files
   const templateDir = path.join(__dirname, '..', 'templates', template)
   await fs.copy(templateDir, targetDir)
-  
+
+  if (packages.includes('rapier')) {
+    await applyPackageVariant(targetDir, template, 'rapier')
+  }
+
   // Replace template variables in files
   await replaceTemplateVariables(targetDir, name)
   

--- a/templates/README.md
+++ b/templates/README.md
@@ -45,6 +45,17 @@ A complete Nuxt 3 application with TresJS integration:
 - `nuxt.config.ts` - Nuxt configuration with TresJS module
 - `package.json` - Dependencies and scripts
 
+## Variants (`variants/`)
+
+Optional overrides applied on top of a template when the matching ecosystem package is selected. This directory is never copied as a whole; the CLI picks individual files out of it.
+
+Layout: `variants/<package>/<template>/<file>`
+
+- `variants/rapier/vue/TheExperience.vue` - replaces `src/components/TheExperience.vue`
+- `variants/rapier/nuxt/TheExperience.vue` - replaces `components/TheExperience.vue`
+
+Both showcase a `<Physics>` world (wrapped in `<Suspense>`, required by Rapier's async wasm) with a bouncing `RigidBody` sphere on a fixed floor.
+
 ## Template Variables
 
 Both templates use the following variables that should be replaced during scaffolding:

--- a/templates/variants/rapier/nuxt/TheExperience.vue
+++ b/templates/variants/rapier/nuxt/TheExperience.vue
@@ -1,0 +1,41 @@
+<template>
+  <TresPerspectiveCamera
+    :position="[10, 10, 10]"
+    :look-at="[0, 0, 0]"
+  />
+  <TresAmbientLight
+    :intensity="0.5"
+    color="white"
+  />
+  <TresDirectionalLight
+    :position="[0, 8, 4]"
+    :intensity="1"
+    cast-shadow
+  />
+
+  <!-- Physics and RigidBody are auto-imported by @tresjs/nuxt -->
+  <!-- Physics loads Rapier's wasm asynchronously, so it needs a Suspense boundary -->
+  <Suspense>
+    <Physics>
+      <RigidBody
+        collider="ball"
+        :restitution="0.8"
+      >
+        <TresMesh :position="[0, 8, 0]">
+          <TresSphereGeometry :args="[1, 32, 32]" />
+          <TresMeshToonMaterial color="#00dc82" />
+        </TresMesh>
+      </RigidBody>
+
+      <RigidBody type="fixed">
+        <TresMesh>
+          <TresPlaneGeometry
+            :args="[20, 20]"
+            :rotate-x="-Math.PI / 2"
+          />
+          <TresMeshBasicMaterial color="#1a2332" />
+        </TresMesh>
+      </RigidBody>
+    </Physics>
+  </Suspense>
+</template>

--- a/templates/variants/rapier/vue/TheExperience.vue
+++ b/templates/variants/rapier/vue/TheExperience.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { Physics, RigidBody } from '@tresjs/rapier'
+</script>
+
+<template>
+  <TresPerspectiveCamera
+    :position="[10, 10, 10]"
+    :look-at="[0, 0, 0]"
+  />
+  <TresAmbientLight
+    :intensity="0.5"
+    color="white"
+  />
+  <TresDirectionalLight
+    :position="[0, 8, 4]"
+    :intensity="1"
+    cast-shadow
+  />
+
+  <!-- Physics loads Rapier's wasm asynchronously, so it needs a Suspense boundary -->
+  <Suspense>
+    <Physics>
+      <RigidBody
+        collider="ball"
+        :restitution="0.8"
+      >
+        <TresMesh :position="[0, 8, 0]">
+          <TresSphereGeometry :args="[1, 32, 32]" />
+          <TresMeshNormalMaterial />
+        </TresMesh>
+      </RigidBody>
+
+      <RigidBody type="fixed">
+        <TresMesh>
+          <TresPlaneGeometry
+            :args="[20, 20]"
+            :rotate-x="-Math.PI / 2"
+          />
+          <TresMeshBasicMaterial color="#f4f4f4" />
+        </TresMesh>
+      </RigidBody>
+    </Physics>
+  </Suspense>
+</template>


### PR DESCRIPTION
## Summary

- Add `@tresjs/rapier` (physics powered by Rapier) to the selectable `ECOSYSTEM_PACKAGES`, so it gets injected as a dependency like the other ecosystem packages
- Introduce a `templates/variants/` mechanism: when a package is selected, the CLI swaps the default `TheExperience.vue` for a variant showcasing that package
- Add rapier variants for both templates (`variants/rapier/vue`, `variants/rapier/nuxt`): a `<Physics>` world wrapped in `<Suspense>` (Rapier loads its wasm async) with a bouncing `RigidBody` sphere on a fixed floor
- Document the variants layout in `templates/README.md` and list rapier in the root `README.md`

## Notes

`applyPackageVariant` is a no-op if the variant file is missing, so adding future variants is drop-in. Variant selection is currently hardcoded to `rapier` in `createProject`; generalize when a second package needs one.

## Test plan

- [ ] `pnpm build && node bin/index.js my-app` → select **vue** + **@tresjs/rapier**, verify `@tresjs/rapier` in `package.json` and the physics `TheExperience.vue` in `src/components/`
- [ ] Same with **nuxt**, verify variant lands in `components/TheExperience.vue`
- [ ] Deselect rapier → default `TheExperience.vue` unchanged
- [ ] Install + `dev` in a generated vue app: sphere falls and bounces on the floor
- [ ] Same for a generated nuxt app (auto-imported `Physics`/`RigidBody` resolve, no SSR error)